### PR TITLE
Notification updates

### DIFF
--- a/EmberMate.xcodeproj/project.pbxproj
+++ b/EmberMate.xcodeproj/project.pbxproj
@@ -363,6 +363,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
+				MACOSX_DEPLOYMENT_TARGET = 14.6;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.matthewnitschke.ember-mate";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -396,6 +397,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
+				MACOSX_DEPLOYMENT_TARGET = 14.6;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.matthewnitschke.ember-mate";
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/EmberMate/AppState.swift
+++ b/EmberMate/AppState.swift
@@ -37,6 +37,8 @@ class AppState: ObservableObject {
         )
     ]
 
+    @Published var notificationsDisabled = false
+    
     @AppStorage("notifyOnTemperatureReached") var notifyOnTemperatureReached: Bool = true
     @AppStorage("notifyOnLowBattery") var notifyOnLowBattery: Bool = true
 
@@ -91,39 +93,49 @@ class AppState: ObservableObject {
             }
             .store(in: &cancellables)
         
-        requestNotificationAuthorization(provisional: true)
+        Task { @MainActor in
+            await requestNotificationAuthorization(provisional: true)
+            await updateNotificationsDisabled()
+        }
+    }
+    
+    @MainActor
+    func updateNotificationsDisabled() async {
+        let settings = await UNUserNotificationCenter.current().notificationSettings()
+        self.notificationsDisabled = settings.authorizationStatus == .denied
     }
 
-    private func requestNotificationAuthorization(provisional: Bool) {
-        Task { @MainActor in
-            let settings = await UNUserNotificationCenter.current().notificationSettings()
-            
-            guard settings.authorizationStatus == .notDetermined
-               || !provisional && settings.authorizationStatus == .provisional
-            else {
-                return
+    @MainActor
+    private func requestNotificationAuthorization(provisional: Bool) async {
+        let settings = await UNUserNotificationCenter.current().notificationSettings()
+        
+        guard settings.authorizationStatus == .notDetermined
+            || !provisional && settings.authorizationStatus == .provisional
+        else {
+            return
+        }
+        
+        do {
+            var options: UNAuthorizationOptions = [.alert, .sound]
+            if provisional {
+                options.insert(.provisional)
             }
             
-            do {
-                var options: UNAuthorizationOptions = [.alert, .sound]
-                if provisional {
-                    options.insert(.provisional)
-                }
-                
-                let authorized = try await UNUserNotificationCenter.current()
-                    .requestAuthorization(options: options)
-                
-                print("Notifications \(authorized ? "" : "not ")authorized")
-            } catch {
-                print("Notifications not authorized: \(error)")
-            }
+            let authorized = try await UNUserNotificationCenter.current()
+                .requestAuthorization(options: options)
+            
+            print("Notifications \(authorized ? "" : "not ")authorized")
+        } catch {
+            print("Notifications not authorized: \(error)")
         }
     }
     
     func startTimer(_ time: Int) {
         timer?.invalidate()
         
-        requestNotificationAuthorization(provisional: false)
+        Task { @MainActor in
+            await requestNotificationAuthorization(provisional: false)
+        }
         
         self.countdown = time
         timer = Timer.scheduledTimer(withTimeInterval: 1, repeats: true) { t in

--- a/EmberMate/Components/TimerView.swift
+++ b/EmberMate/Components/TimerView.swift
@@ -11,10 +11,21 @@ import SwiftUI
 struct TimerView: View {
     @ObservedObject var appState: AppState
 
+    @Environment(\.openURL) var openURL
+    
     var body: some View {
         HStack(alignment: .center) {
-            Image(systemName: "timer")
-                .font(.system(size: 20))
+            if appState.notificationsDisabled {
+                Image(systemName: "exclamationmark.triangle.fill")
+                    .font(.system(size: 20))
+                    .help("Notifications are disabled. Click to open System Settings.")
+                    .onTapGesture {
+                        self.openURL(.notificationSettings)
+                    }
+            } else {
+                Image(systemName: "timer")
+                    .font(.system(size: 20))
+            }
             Text("Timer")
                 .font(.system(size: 14))
             Spacer()
@@ -41,6 +52,9 @@ struct TimerView: View {
         .padding(10)
         .background(Color.black.opacity(0.29))
         .cornerRadius(9)
+        .task {
+            await appState.updateNotificationsDisabled()
+        }
     }
 }
 

--- a/EmberMate/NotificationAdapter.swift
+++ b/EmberMate/NotificationAdapter.swift
@@ -19,6 +19,8 @@ class NotificationAdapter {
     private var previousLiquidState: LiquidState?
     private var lastNotifiedTemp: Double?
 
+    private var wasLowBattery: Bool = false
+    
     init(appState: AppState, emberMug: EmberMug) {
         self.appState = appState
         self.emberMug = emberMug
@@ -39,8 +41,13 @@ class NotificationAdapter {
 
         self.emberMug.$batteryLevel
             .sink { newData in
-                if (newData == 15 && !self.emberMug.isCharging) {
-                    self.notifyLowBattery()
+                if newData <= 15 {
+                    if !self.wasLowBattery && !self.emberMug.isCharging {
+                        self.notifyLowBattery()
+                    }
+                    self.wasLowBattery = true
+                } else {
+                    self.wasLowBattery = false
                 }
             }
             .store(in: &cancellables)


### PR DESCRIPTION
- **Request provisional notification authorization on app launch and non-provisional authorization when starting a timer**
  
  Currently the app only asks for permissions when starting a timer, so battery and temperature notifications are never received. With this PR, users will see temperature & battery alerts without prompting, and they can decide to keep notifications on or not. Also, timers are much less useful without notifications so we directly ask the user then.

- **Notify temperature whenever a stable temperature is reached if we haven't already notified for that temp**
  **Notify low battery for values <= 15 too (if we haven't already)**

  This should fix some edge cases where notifications aren't received for valid situations.

- **Update UI if notifications are disabled**

  `SettingsView` disables notification toggles and displays a button to open System Settings.
  `TimerView` displays a warning icon with a tooltip that opens System Settings when clicked.