### PR TITLE
Revert deployment target to macOS 13.1

### DIFF
--- a/EmberMate.xcodeproj/project.pbxproj
+++ b/EmberMate.xcodeproj/project.pbxproj
@@ -364,7 +364,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 14.6;
+				MACOSX_DEPLOYMENT_TARGET = 13.1;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.matthewnitschke.ember-mate";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -399,7 +399,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 14.6;
+				MACOSX_DEPLOYMENT_TARGET = 13.1;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.matthewnitschke.ember-mate";
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/EmberMate/Components/ContextMenu.swift
+++ b/EmberMate/Components/ContextMenu.swift
@@ -17,9 +17,9 @@ class ContextMenu: NSObject, NSMenuDelegate {
 
     private var bluetoothManager: BluetoothManager
     private var emberMug: EmberMug
-    private var openSettings: OpenSettingsAction
+    private var openSettings: () -> Void
 
-    init(bluetoothManager: BluetoothManager, emberMug: EmberMug, openSettings: OpenSettingsAction) {
+    init(bluetoothManager: BluetoothManager, emberMug: EmberMug, openSettings: @escaping () -> Void) {
         self.bluetoothManager = bluetoothManager
         self.emberMug = emberMug
         self.openSettings = openSettings

--- a/EmberMate/ember_mateApp.swift
+++ b/EmberMate/ember_mateApp.swift
@@ -17,7 +17,7 @@ struct ember_mateApp: App {
     @State private var isMenuPresented = false
     @State private var statusItem: NSStatusItem?
     
-    @Environment(\.openSettings) private var openSettings
+    @Environment(\.openSettings_backport) private var openSettings
 
     private var notificationAdapter: NotificationAdapter
 
@@ -103,5 +103,26 @@ struct ember_mateApp: App {
             return ">1min"
         }
         return "\(minutes)min"
+    }
+}
+
+private struct OpenSettingsBackportKey: EnvironmentKey {
+    static let defaultValue: () -> Void = {
+        NSApp.sendAction(Selector(("showSettingsWindow:")), to: nil, from: nil)
+    }
+}
+
+extension EnvironmentValues {
+    fileprivate var openSettings_backport: () -> Void {
+        get {
+            if #available(macOS 14.0, *) {
+                return { [openSettings] in
+                    openSettings()
+                }
+            } else {
+                return self[OpenSettingsBackportKey.self]
+            }
+        }
+        set { self[OpenSettingsBackportKey.self] = newValue }
     }
 }


### PR DESCRIPTION
This re-establishes macOS 13.1 compatibility by adding a backport for opening settings view on iOS 13 vs iOS 14