### PR TITLE
Optionally show battery level in menu bar when charging

### DIFF
--- a/EmberMate/AppState.swift
+++ b/EmberMate/AppState.swift
@@ -41,6 +41,7 @@ class AppState: ObservableObject {
     
     @AppStorage("notifyOnTemperatureReached") var notifyOnTemperatureReached: Bool = true
     @AppStorage("notifyOnLowBattery") var notifyOnLowBattery: Bool = true
+    @AppStorage("showBatteryLevelWhenCharging") var showBatteryLevelWhenCharging: Bool = false
 
     private var cancellables: Set<AnyCancellable> = []
 

--- a/EmberMate/Utils.swift
+++ b/EmberMate/Utils.swift
@@ -23,6 +23,10 @@ func getFormattedTemperature(_ temp: Double, unit: TemperatureUnit) -> String {
     return String(format: "%.0f°", (temp * 9/5) + 32)
 }
 
+func getFormattedBatteryLevel(_ batteryLevel: Int) -> String {
+    return String(format: "%d%%", batteryLevel)
+}
+
 func formatTime(_ seconds: Int) -> String {
     let minutes = seconds / 60
     let remainingSeconds = seconds % 60

--- a/EmberMate/Views/SettingsView.swift
+++ b/EmberMate/Views/SettingsView.swift
@@ -106,7 +106,13 @@ struct GeneralSettingsView: View {
                         Text("Notify on low battery (15%)")
                             .opacity(appState.notificationsDisabled ? 0.5 : 1)
                     }
-                        .disabled(appState.notificationsDisabled)
+                    .disabled(appState.notificationsDisabled)
+                }
+                
+                Section {
+                    Toggle(isOn: appState.$showBatteryLevelWhenCharging) {
+                        Text("Show battery level in menubar when charging")
+                    }
                 }
             }
         }

--- a/EmberMate/ember_mateApp.swift
+++ b/EmberMate/ember_mateApp.swift
@@ -43,6 +43,8 @@ struct ember_mateApp: App {
                     Text(formatCountdown(appState.countdown!))
                 } else if (bluetoothManager.state == .connected && emberMug.liquidState != .empty) {
                     Text(getFormattedTemperature(emberMug.currentTemp, unit: emberMug.temperatureUnit))
+                } else if (bluetoothManager.state == .connected && emberMug.liquidState == .empty && emberMug.batteryLevel != 100 && emberMug.isCharging && appState.showBatteryLevelWhenCharging) {
+                    Text(getFormattedBatteryLevel(emberMug.batteryLevel))
                 }
             }
         }.menuBarExtraAccess(isPresented: $isMenuPresented) { statusItem in


### PR DESCRIPTION
So I was getting impatient when my mug had low battery, and could not make a fresh cup of team, so I wanted to quickly see where the battery is at, without having to keep dive into the settings.

That said, now that I'm looking at it, I think I we can extend this to (optionally) also show the battery level when the mug is in use.  When the battery is getting low, you may want to hurry up and finish that drink. WDYT?