### PR TITLE
Press and hold to update the preset temp

### DIFF
--- a/EmberMate/Components/IconButton.swift
+++ b/EmberMate/Components/IconButton.swift
@@ -14,6 +14,7 @@ struct IconButton: View {
     var icon: String
     var isSelected: Bool
     var onSelect: () -> Void
+    var onLongPress: (() -> Void)? = nil
 
     var body: some View {
         Button(action: {
@@ -40,5 +41,11 @@ struct IconButton: View {
         }
         .buttonStyle(.plain)
         .cornerRadius(9)
+        .simultaneousGesture(
+            LongPressGesture(minimumDuration: 0.5)
+                .onEnded { _ in
+                    onLongPress?()
+                }
+        )
     }
 }

--- a/EmberMate/Components/TemperaturePresetButton.swift
+++ b/EmberMate/Components/TemperaturePresetButton.swift
@@ -13,6 +13,7 @@ struct TemperaturePresetButton: View {
     var temperatureUnit: TemperatureUnit
     var isSelected: Bool
     var onSelect: (Double) -> Void
+    var onLongPress: ((Double) -> Void)? = nil
 
     var body: some View {
         IconButton(
@@ -22,6 +23,9 @@ struct TemperaturePresetButton: View {
             isSelected: isSelected,
             onSelect: {
                 onSelect(preset.temperature)
+            },
+            onLongPress: {
+                onLongPress?(preset.temperature)
             }
         )
     }

--- a/EmberMate/Views/MugControlView.swift
+++ b/EmberMate/Views/MugControlView.swift
@@ -70,6 +70,17 @@ struct MugControlView: View {
                         onSelect: {
                             appState.selectedPreset = preset
                             emberMug.setTargetTemp(temp: $0)
+                        },
+                        onLongPress: { _ in
+                            if let index = appState.presets.firstIndex(where: { $0.id == preset.id }) {
+                                let updatedPreset = Preset(
+                                    icon: appState.presets[index].icon,
+                                    name: appState.presets[index].name,
+                                    temperature: emberMug.targetTemp
+                                )
+                                updatedPreset.id = appState.presets[index].id
+                                appState.presets[index] = updatedPreset
+                            }
                         }
                     )
                 }


### PR DESCRIPTION
Added the ability to press and hold on the preset icon to update the temperature to the current target temp. This offers a more convenient way of updating preset values, without requiring opening the settings

Closes #23