### PR TITLE
Remove deprecated SwiftUICore import for macOS 26.2 compatibility

### DIFF
--- a/EmberMate/Components/ContextMenu.swift
+++ b/EmberMate/Components/ContextMenu.swift
@@ -9,7 +9,6 @@ import Foundation
 
 import Cocoa
 import UserNotifications
-import SwiftUICore
 import SwiftUI
 
 class ContextMenu: NSObject, NSMenuDelegate {


### PR DESCRIPTION
Fixed import for macOS 26.2 compatibility.
Removed depricated SwiftUICore import from ContextMenu.swift. SwiftUICore is now
an implementation detail of SwiftUI and cannot be imported directly.
