### PR TITLE
fixed package script

### DIFF
--- a/package.mjs
+++ b/package.mjs
@@ -10,13 +10,13 @@
  * Execution: `$ ./package.mjs`
  */
 
-const currentVersion = (await $`agvtool what-version -terse`).text().trim()
+const currentVersion = (await $`grep -m 1 "MARKETING_VERSION = " ./EmberMate.xcodeproj/project.pbxproj | sed -E 's/.*MARKETING_VERSION = ([0-9.]+);.*/\\1/'`).text().trim()
 
 const shouldUpdate = (await question(`Current project version is ${currentVersion}. Would you like to update this? (Y/n): `)).trim().toLowerCase()
 if (shouldUpdate == '' || shouldUpdate == 'y') {
   const newVersion = (await question(`Enter new version: `)).trim()
-  await $`agvtool new-version ${newVersion}`
-  await $`agvtool new-marketing-version ${newVersion}`
+
+  await $`sed -i '' "s/MARKETING_VERSION = .*;/MARKETING_VERSION = ${newVersion};/" ./EmberMate.xcodeproj/project.pbxproj`
 }
 
 await spinner('Building Project', () => $`


### PR DESCRIPTION
agvtool was being silly, and I don't care enough to dig into why

Opting to simply just use `grep`, and `sed` to assign version numbers to unblock the package script and let the next EmberMate version get released