### PR TITLE
Fixes #43 : Gradient background at full when temperate >= 63 degrees

### DIFF
--- a/EmberMate/Views/MugControlView.swift
+++ b/EmberMate/Views/MugControlView.swift
@@ -129,7 +129,7 @@ struct MugControlView: View {
         if (currentTemp <= 50) {
             val = 0.0
         } else if (currentTemp >= 63) {
-            val = 13
+            val = 13.0
         } else {
             val = Double(currentTemp - 50)
         }

--- a/EmberMate/Views/MugControlView.swift
+++ b/EmberMate/Views/MugControlView.swift
@@ -129,7 +129,7 @@ struct MugControlView: View {
         if (currentTemp <= 50) {
             val = 0.0
         } else if (currentTemp >= 63) {
-            val = 1.0
+            val = 13
         } else {
             val = Double(currentTemp - 50)
         }


### PR DESCRIPTION
Background gradient was incorrect for higher temperature. 
Updated value passed to "getBackgroundGradient" in order to get back a correct gradient value.

<details>
<summary>Before</summary>

### Before
Lighter background when temperature is high
<img width="296" height="232" alt="Screenshot 2026-04-25 at 20 54 59" src="https://github.com/user-attachments/assets/75e482a0-c231-4f48-b82e-835cf3f65d33" />
Darker background after temperature < 63
<img width="309" height="247" alt="Screenshot 2026-04-25 at 21 05 58" src="https://github.com/user-attachments/assets/48b6e063-605f-46bd-a407-83c4c35e4f90" />
</details>

<details>
<summary>After</summary>

### After
Darker background when temperature >= 63
<img width="302" height="239" alt="Screenshot 2026-04-25 at 21 02 51" src="https://github.com/user-attachments/assets/27dca9c6-f5f4-480b-b9a4-8f2343d2732c" />
Slightly lighter background when temperature < 63
<img width="303" height="248" alt="Screenshot 2026-04-25 at 21 05 44" src="https://github.com/user-attachments/assets/abf3457e-2b44-493b-949c-557a92d920ef" />
Much lighter background at low temperature
<img width="292" height="235" alt="Screenshot 2026-04-25 at 21 08 12" src="https://github.com/user-attachments/assets/1e823263-1824-4fda-9266-9f4534f1da40" />

</details>

Closes #43 