### PR TITLE
Support mug name

### DIFF
--- a/EmberMate/EmberMug.swift
+++ b/EmberMate/EmberMug.swift
@@ -31,6 +31,7 @@ class EmberMug: NSObject, ObservableObject, CBPeripheralDelegate {
     @Published var liquidState: LiquidState = LiquidState.empty
     @Published var temperatureUnit: TemperatureUnit = TemperatureUnit.celcius
     @Published var color: Color = Color.white
+    @Published var mugName: String = ""
 
     var peripheral: CBPeripheral?
 
@@ -40,6 +41,12 @@ class EmberMug: NSObject, ObservableObject, CBPeripheralDelegate {
     private var liquidStateCharacteristic: CBCharacteristic?
     private var temperatureUnitCharacteristic: CBCharacteristic?
     private var colorCharacteristic: CBCharacteristic?
+    private var mugNameCharacteristic: CBCharacteristic?
+
+    private var storedMugNames: [String: String] {
+        get { UserDefaults.standard.dictionary(forKey: "mugNames") as? [String: String] ?? [:] }
+        set { UserDefaults.standard.set(newValue, forKey: "mugNames") }
+    }
 
     private var cancellables: Set<AnyCancellable> = []
 
@@ -93,6 +100,21 @@ class EmberMug: NSObject, ObservableObject, CBPeripheralDelegate {
         peripheral?.writeValue(Data([red, green, blue, alpha]), for: colorCharacteristic!, type: .withResponse)
     }
 
+    func setMugName(_ name: String) {
+        if let characteristic = mugNameCharacteristic {
+            let cleaned = String(name.filter { $0.isASCII }.filter { $0 != " " }.prefix(14))
+            guard let data = cleaned.data(using: .ascii) else { return }
+            mugName = cleaned
+            peripheral?.writeValue(data, for: characteristic, type: .withResponse)
+        } else {
+            let cleaned = String(name.filter { $0.isASCII }.prefix(20))
+            mugName = cleaned
+            var names = storedMugNames
+            names[peripheral!.identifier.uuidString] = cleaned
+            storedMugNames = names
+        }
+    }
+
     func peripheral(_ peripheral: CBPeripheral, didDiscoverServices error: Error?) {
         self.peripheral = peripheral
         for service: CBService in peripheral.services! {
@@ -119,6 +141,8 @@ class EmberMug: NSObject, ObservableObject, CBPeripheralDelegate {
                 temperatureUnitCharacteristic = characteristic
             case CBUUID(string: "fc540014-236c-4c94-8fa9-944a3e5353fa"):
                 colorCharacteristic = characteristic
+            case CBUUID(string: "fc540001-236c-4c94-8fa9-944a3e5353fa"):
+                mugNameCharacteristic = characteristic
             case CBUUID(string: "fc540012-236c-4c94-8fa9-944a3e5353fa"):
                 // enable notifications for the event characteristic
                 peripheral.setNotifyValue(true, for: characteristic)
@@ -129,6 +153,11 @@ class EmberMug: NSObject, ObservableObject, CBPeripheralDelegate {
             // read the initial value
             // TODO: probably only do this if its a value we care about
             peripheral.readValue(for: characteristic)
+        }
+
+        if mugNameCharacteristic == nil {
+            let uuid = peripheral.identifier.uuidString
+            mugName = storedMugNames[uuid] ?? peripheral.name ?? ""
         }
     }
 
@@ -159,6 +188,10 @@ class EmberMug: NSObject, ObservableObject, CBPeripheralDelegate {
                 let blue = Double(data[2])
                 let alpha = Double(data[3])
                 color = Color(red: red/255, green: green/255, blue: blue/255, opacity: alpha/255)
+            } else if (characteristic == mugNameCharacteristic) {
+                if let name = String(data: data, encoding: .ascii) {
+                    mugName = name
+                }
             } else if (characteristic.uuid == CBUUID(string: "fc540012-236c-4c94-8fa9-944a3e5353fa")) {
                 let state = Int(data[0])
 

--- a/EmberMate/Views/MugControlView.swift
+++ b/EmberMate/Views/MugControlView.swift
@@ -19,7 +19,7 @@ struct MugControlView: View {
     var body: some View {
         VStack {
             HStack(alignment: .center) {
-                Text(emberMug.peripheral?.name ?? "")
+                Text(emberMug.mugName)
                     .font(.caption)
                 Spacer()
                 BatteryView(

--- a/EmberMate/Views/Settings/SettingsView.swift
+++ b/EmberMate/Views/Settings/SettingsView.swift
@@ -32,6 +32,7 @@ struct GeneralSettingsView: View {
     @EnvironmentObject private var bluetoothManager: BluetoothManager
     
     @Environment(\.openURL) var openURL
+    @FocusState private var nameFocused: Bool
     
     var body: some View {
         Form {
@@ -45,7 +46,12 @@ struct GeneralSettingsView: View {
                         Image(systemName: "mug.fill")
                             .font(.largeTitle)
                         VStack(alignment: .leading) {
-                            Text(emberMug.peripheral?.name ?? "Unknown Device")
+                            TextField("Name", text: $emberMug.mugName)
+                                .labelsHidden()
+                                .focused($nameFocused)
+                                .onSubmit {
+                                    emberMug.setMugName(emberMug.mugName)
+                                }
                             BatteryView(
                                 display: .both,
                                 batteryLevel: emberMug.batteryLevel,


### PR DESCRIPTION
Start of multi-mug support, we need a way to identify mugs before supporting multiple of them

Note, not all mugs can store a name on the device, because of this, we have to store the mug name locally in those cases
* Mug: full support
* Cup: no support, name stored locally
* Tumbler: no support, name stored locally
* Travel Mug: read only