### PR TITLE
Remove show battery when charging option

### DIFF
--- a/EmberMate/AppState.swift
+++ b/EmberMate/AppState.swift
@@ -41,7 +41,6 @@ class AppState: ObservableObject {
     
     @AppStorage("notifyOnTemperatureReached") var notifyOnTemperatureReached: Bool = true
     @AppStorage("notifyAtBatteryPercentage") var notifyAtBatteryPercentage: LowBatteryLevel = .default
-    @AppStorage("showBatteryLevelWhenCharging") var showBatteryLevelWhenCharging: Bool = false
     
     private var cancellables: Set<AnyCancellable> = []
 

--- a/EmberMate/Views/Settings/SettingsView.swift
+++ b/EmberMate/Views/Settings/SettingsView.swift
@@ -105,12 +105,6 @@ struct GeneralSettingsView: View {
                 
             }
         
-            Section {
-                Toggle(isOn: appState.$showBatteryLevelWhenCharging) {
-                    Text("Show battery level in menubar when charging")
-                }
-            }
-            
         }
         .formStyle(.grouped)
         .task {

--- a/EmberMate/ember_mateApp.swift
+++ b/EmberMate/ember_mateApp.swift
@@ -40,7 +40,7 @@ struct ember_mateApp: App {
                     Text(formatCountdown(appState.countdown!))
                 } else if (bluetoothManager.state == .connected && emberMug.liquidState != .empty) {
                     Text(getFormattedTemperature(emberMug.currentTemp, unit: emberMug.temperatureUnit))
-                } else if (bluetoothManager.state == .connected && emberMug.liquidState == .empty && emberMug.batteryLevel != 100 && emberMug.isCharging && appState.showBatteryLevelWhenCharging) {
+                } else if (bluetoothManager.state == .connected && emberMug.liquidState == .empty && emberMug.batteryLevel != 100 && emberMug.isCharging) {
                     Text(getFormattedBatteryLevel(emberMug.batteryLevel))
                 }
             }


### PR DESCRIPTION
Removed the option to configure whether the battery percentage is visible in the menubar when charging

EmberMate is an opinionated application, leaning on basic functionality more than trying to be incredible configurable. This setting enabled a good feature that's helpful, so just always enable it